### PR TITLE
Improved imports in testing functions

### DIFF
--- a/findoutlie/tests/test_detectors.py
+++ b/findoutlie/tests/test_detectors.py
@@ -1,27 +1,16 @@
-""" Test script for detector functions
+"""Test script for detector functions.
 
-Run these tests with::
+To run these scripts, use pytest, e.g. 
 
-    python3 findoutlie/tests/test_detectors.py
+    pytest findoutlie/tests/
 
-or better, in IPython::
-
-    %run findoutlie/tests/test_detectors.py
 """
-
-from pathlib import Path
-import sys
-
-MY_DIR = Path(__file__).parent
-
-sys.path.append(str(MY_DIR.parent))
 
 import numpy as np
 
-# This import needs the directory containing the findoutlie directory
-# on the Python path.
-from detectors import iqr_detector
+from pathlib import Path
 
+from ..detectors import iqr_detector
 
 def test_iqr_detector():
     # From: http://www.purplemath.com/modules/boxwhisk3.htm
@@ -33,9 +22,3 @@ def test_iqr_detector():
     # Test not-default value for outlier proportion
     is_outlier = iqr_detector(example_values, 0.5)
     assert np.all(example_values[is_outlier] == [10.2, 14.1, 15.1, 15.9, 16.4])
-
-
-if __name__ == '__main__':
-    # File being executed as a script
-    test_iqr_detector()
-    print('Tests passed')

--- a/findoutlie/tests/test_dvars.py
+++ b/findoutlie/tests/test_dvars.py
@@ -1,17 +1,16 @@
-""" Test dvars implementation
+""" Test dvars implementation.
 
-You can run the tests from the root directory (containing ``README.md``) with::
+To run these scripts, use pytest, e.g. 
 
-    python3 -m pytest .
+    pytest findoutlie/tests/
+
 """
 
 import numpy as np
-
 import nibabel as nib
-
 import nipraxis as npx
 
-from findoutlie.metrics import dvars
+from ..metrics import dvars
 
 
 TEST_FNAME = npx.fetch_file('ds114_sub009_t2r1.nii')

--- a/findoutlie/tests/test_spm_funcs.py
+++ b/findoutlie/tests/test_spm_funcs.py
@@ -1,29 +1,21 @@
-""" Test script for SPM functions
+"""Test script for SPM functions.
 
-Run these tests with::
+To run these scripts, use pytest, e.g. 
 
-    python3 findoutlie/tests/test_spm_funcs.py
+    pytest findoutlie/tests/
 
-or better, in IPython::
-
-    %run findoutlie/tests/test_spm_funcs.py
 """
 
-from pathlib import Path
+import nibabel as nib
+import numpy as np
 import sys
 
+from pathlib import Path
+
+from ..spm_funcs import get_spm_globals, spm_global
+ 
 MY_DIR = Path(__file__).parent
 EXAMPLE_FILENAME = 'ds107_sub012_t1r2_small.nii'
-
-sys.path.append(str(MY_DIR.parent))
-
-import numpy as np
-
-import nibabel as nib
-
-# This import needs the directory containing the findoutlie directory
-# on the Python path.
-from spm_funcs import get_spm_globals, spm_global
 
 
 def test_spm_globals():
@@ -40,9 +32,3 @@ def test_spm_globals():
         vol = data[..., vol_no]
         globals.append(spm_global(vol))
     assert np.allclose(globals, expected_values, rtol=1e-4)
-
-
-if __name__ == '__main__':
-    # File being executed as a script
-    test_spm_globals()
-    print('Tests passed')


### PR DESCRIPTION
`findoutlie/tests/` is now a proper subpackage. This lets test scripts like `test_dvars` import modules of `findoutlie` using relative imports (e.g. `from ..metrics import dvars`). Thus, `pytest` won't complain about not finding the `findoutlie` package and we won't have to install Flit.

Note that it won't by possible to run these tests as simple scripts, like `python findoutlie/tests/test_dvars.py`.